### PR TITLE
LFP3: use not_materialized for stake type

### DIFF
--- a/src/org/interlis2/av2geobau/impl/Mapper.java
+++ b/src/org/interlis2/av2geobau/impl/Mapper.java
@@ -349,7 +349,7 @@ public class Mapper {
         }else if(punktzeichen.equals(Versicherungsart.tag_Kreuz)) {
             block="LFP3KR";
             layer="01133";
-        }else if(punktzeichen.equals(Versicherungsart.tag_unversichert)) {
+        }else if(punktzeichen.equals(Versicherungsart.tag_unversichert) || punktzeichen.equals(Versicherungsart.tag_Pfahl)) {
             block="LFP3UV";
             layer="01134";
         }else {


### PR DESCRIPTION
LPF3 und Pfahl dürfte fachlich gesehen wohl nicht ganz lupenrein sein. Und in den DXF-Geobau-Listen anderer Kantone habe ich ich keine LFP3-Pfahl gefunden.

So geht er jedenfalls nicht verloren. 